### PR TITLE
LibreELEC settings: handle etree XPath quirks

### DIFF
--- a/files/update_xml.py
+++ b/files/update_xml.py
@@ -19,6 +19,14 @@ filename = os.path.join('/storage/.kodi', filename)
 tree = et.parse(filename)
 root = tree.getroot()
 
+tag, *rest = path.split('/')
+
+if root.tag != tag:
+    print('Document "{0}" uses root tag "{1}", not the supplied tag "{2}"'.format(filename, root.tag, tag))
+    sys.exit(1)
+
+path = '/'.join(rest)
+
 # do we need to create this node/tree?
 match = root.find(path)
 

--- a/files/update_xml.py
+++ b/files/update_xml.py
@@ -23,7 +23,7 @@ root = tree.getroot()
 match = root.find(path)
 
 # ok, yes we do
-if not match:
+if match is None:
     path_components = re.findall(r'[a-z0-9]+(?:\[@[^]]+\])?', path)
     mount_element = root
     for node in path_components:


### PR DESCRIPTION
1. Explicitly check whether the return value of `xml.etree.ElementTree.find` is `None`, versus testing whether it is falsey.  Some(?) XPath paths match, but still act falsey in conditionals.
2. Handle a quirk of `xml.etree.ElementTree.find` where a query like `root.find(/settings/setting[@id="foo"])` does not match the document

```xml
<settings>
<setting id="foo">...</foo>
</settings>
```

It seems like the root tag cannot be included in XPath queries, for some reason :shrug: 