### PR TITLE
docs: add description of `kodi_config` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ See ["Installing Addons"](#installing-addons) and ["Configuring Addon Settings"]
 Role Variables
 --------------
 
+[`vars/default.yml`]: vars/default.yml
+
 - `kodi_user`: the user account used for running the Kodi service on the target machine.  Default: `"kodi"`.
 - `kodi_groups`: if `kodi_user` is created by this role, it will be added to these groups.  Default: `["audio", "video", "input"]`.
 - `kodi_shell`: if `kodi_user` is created by this role, it will use this value as its login shell.  Default: `"/bin/bash"`.
@@ -84,6 +86,11 @@ Role Variables
 - `kodi_repositories`: a list of strings of the form `<repository-name>=<repository-url>`, where `repository-name` is an arbitrary identifier and `repository-url` is the URL to a Kodi repository `addons.xml` file.  Default: `[]`.
 - `kodi_enabled_repositories`: a list of repository name strings.  Each element should correspond to the `repository-name` part of the `<repository-name>=<repository-url>` entries in `kodi_repositories`.  Addons in this repository will be available for installation via specifying their names in `kodi_addons`.  Default: all repository names in `kodi_repositories`.
 - `kodi_addons`: a list of addons to install (if necessary) and enable.  Each entry can be an addon name (e.g. `plugin.video.beepboop`) or an `<repository-addon-name>=<addon-url>` pair, `<repository-addon-name>` is the name of a repository addon (`repository.foo.bar`) and `<addon-url>` is the URL of the ZIP archive defining the addon.  In the latter case, the addon ZIP will be fetched and extracted to the named path under `~{{ kodi_user }}/addons`.  Default: `[]`.
+- `kodi_config`: a list of dictionaries specifying configuration data for core Kodi and for addons (see [`vars/default.yml`][] for an example definition).  Default: `[]`.  Each entry must define the following attributes:
+    - `file`: the path to the file (relative to the Kodi data directory, often `~/.kodi`) that should contain this setting.
+    - `key`: an XPath expression matching the target setting (a suitable XML node will be created if a matching node does not already exist).
+    - `value`: the value of the setting.
+    - `type`: the data type of the setting (for instance, `"string"` or `"bool"`).
 - `kodi_setting_level`: an integer representing the setting level (Basic, Standard, Advanced, Expert).  Default: not defined.
 - `kodi_webserver_enabled`: whether or not to enable the Kodi webserver.  Default: not defined.
 - `kodi_webserver_port`: listening port for the Kodi webserver.  Default: not defined.
@@ -94,7 +101,7 @@ Role Variables
 - `kodi_locale_timezone_country`: Default: not defined.
 - `kodi_subtitles_languages`: Comma-separated list of subtitle languages.  Default: not defined.
 - `kodi_weather_provider`: Hostname of the weather data provider.  Default: not defined.
-- `kodi_include_default_config`: a boolean indicating whether or not to include the variable definitions from [`vars/default.yml`](vars/default.yml).  Default: `False`.
+- `kodi_include_default_config`: a boolean indicating whether or not to include the variable definitions from [`vars/default.yml`][].yml).  Default: `False`.
 
 Installing Addons
 -----------------


### PR DESCRIPTION
with a link to example usage.  This fixes my goof-up in omitting said docs from the changes in #2.