### PR TITLE
Add support for testing on embedded distributions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Ignore files and directories when creating archives with `git archive`.
+# This will exclude matching files from the role as distributed on Ansible
+# Galaxy.
+
+/.github/ export-ignore
+/.github/** export-ignore
+/scripts/ export-ignore
+/scripts/** export-ignore
+/tmp/ export-ignore
+/tmp/** export-ignore
+/vagrant/ export-ignore
+/vagrant/** export-ignore
+
+# XXX do not exclude the `/tests/` hierarchy, as doing so breaks GitHub
+# Actions.  That is, do not do this:
+#   /tests/ export-ignore
+#   /tests/** export-ignore
+
+*.nix export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+.travis.yml export-ignore
+CONTRIBUTING.md export-ignore
+Vagrantfile export-ignore
+event.json export-ignore
+flake.lock export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - alpine:3
           - archlinux/archlinux
           - debian:11
           - debian:12
@@ -21,8 +22,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install testing dependencies
         run: |
-          { pacman --noconfirm -Sy archlinux-keyring && pacman --noconfirm -Su && pacman --noconfirm -S ansible sudo ; } || :
+          { apk add --no-cache ansible sudo ; } || :
           { apt -y update && apt -y install ansible sudo ; } || :
+          { pacman --noconfirm -Sy archlinux-keyring && pacman --noconfirm -Su && pacman --noconfirm -S ansible sudo ; } || :
       - name: Run test playbook
         run: |
           ansible-playbook -vv --become -c local -i localhost, ./tests/test.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
           } || :
           { pacman --noconfirm -Sy archlinux-keyring && pacman --noconfirm -Su && pacman --noconfirm -S ansible sudo ; } || :
       - name: Run test playbook
+        # Force `kodi_service_enabled` to `false`, as we can't count on being
+        # able to use the distribution's service manager/supervisor (e.g.
+        # OpenRC under Alpine Linux) in a container.
         run: |
-          ansible-playbook -vv --become -c local -i localhost, ./tests/test.yml
+          ansible-playbook -vv --become -c local -i localhost, -e kodi_service_enabled=false ./tests/test.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ on:
   pull_request:
   push:
   workflow_dispatch:
+env:
+  DEBIAN_FRONTEND: noninteractive
 jobs:
   native:
     name: Run test playbook
@@ -23,7 +25,12 @@ jobs:
       - name: Install testing dependencies
         run: |
           { apk add --no-cache ansible sudo ; } || :
-          { apt -y update && apt -y install ansible sudo ; } || :
+          {
+               echo 'tzdata tzdata/Areas select Europe' | debconf-set-selections \
+            && echo 'tzdata tzdata/Zones/Europe select Bratislava' | debconf-set-selections \
+            && apt -y update \
+            && apt -y install --no-install-recommends ansible sudo
+          } || :
           { pacman --noconfirm -Sy archlinux-keyring && pacman --noconfirm -Su && pacman --noconfirm -S ansible sudo ; } || :
       - name: Run test playbook
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,11 @@
 /.vagrant/
+
+# Vagrant boxes
+*.box
+
+# Disk images
+*.img
+*.qcow2
+
+# libvirt domain log files
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog for `jose1711.kodi_ansible_role`
+
+This file lists all notable changes to this project.
+
+## Unreleased
+
+### Added
+
+- Support for Alpine Linux (#8).
+- Project contribution guide (#8).
+- Support `system` boolean and `gid` numeric attributes in `kodi_groups`
+  entries, permitting greater end-user control over group creation logic (#8).
+- Add the new `kodi_service` variable for managing the Kodi service,
+  emphasizing that this role supports both system and non-systemd service
+  managers (#8).
+
+### Changed
+
+- Create (if necessary) all groups in `kodi_groups` (#8).
+- Use the `service` module rather than the `systemd` for managing the Kodi
+  service, thus supporting (e.g.) OpenRC on Alpine Linux (#8).
+- Deprecate (but do not yet remove or ignore) the `kodi_systemd_service`
+  variable in favor of using the newly-introduced `kodi_service` variable (#8).
+- Exclude testing- and development-only files from the role archive distributed
+  via Ansible Galaxy (#8).
+
+### Fixed
+
+- Use `root` as `kodi_user` on LibreELEC (#8).
+- Use the `wait_for` module instead of the `pause` module; now it should be
+  possible to apply this role under the `free` strategy (#8).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,154 @@
+[`tests/test.yml`]: /tests/test.yml
+[`.github/workflows/ci.yml`]: /.github/workflows/ci.yml
+[Nix development shell]: #nix-development-shell
+
+# Contributing to `jose1711.kodi_ansible_role`
+
+## Nix development shell
+
+This project includes a development environment using the [Nix package
+manager](https://nixos.org).  The environment provides tools for working with
+the `jose1711.kodi-ansible-role` codebase, including Ansible itself, plus
+[Vagrant](#vagrant-environment) and helpers for executing [GitHub Actions
+jobs](#github-actions-suite).
+
+Please see [here](https://nixos.org/download#download-nix) for instructions on
+installing the Nix package manager, and see
+[here](https://nix.dev/tutorials/first-steps/) for a getting-started-with-Nix
+tutorial.
+
+Once you have installed the Nix package manager, you can enter the
+Nix development shell by running the following command from inside this
+project's working tree:
+
+```console
+$ nix --extra-experimental-features 'flakes nix-command' develop
+```
+
+This will start a new shell with development tooling available (print the value
+of the `PATH` environment variable inside the shell for some of the gory
+details).
+
+When you are done with your development environment, you can exit the shell as
+usual (press `<ctrl-d>`, or run `exit`).
+
+## Vagrant environment
+
+This project includes a Vagrant environment for testing the
+`jose1711.kodi_ansible_role` Ansible role on several Linux distributions.  As
+of this writing, those distributions are:
+
+1. Alpine Linux (3.19)
+2. Arch Linux
+3. Debian (12 (bookworm))
+4. Ubuntu (22.04 LTS (Jammy Jellyfish))
+5. LibreELEC (11.0.6)
+6. OSMC (20240205)
+
+This Vagrant environment supports the
+[`libvirt` provider](https://vagrant-libvirt.github.io/vagrant-libvirt/)[^provider-support].
+
+[^provider-support]: Some of the Vagrant boxes employed in this environment may
+                     support other providers, but the LibreELEC and OSMC boxes
+                     support **only** `libvirt`.
+
+To use this Vagrant environment, you will need to install Vagrant itself, as
+well as the `vagrant-libvirt` provider plugin[^vagrant-in-nix-devshell].  Please
+see the [`vagrant-libvirt` installation instructions](https://vagrant-libvirt.github.io/vagrant-libvirt/installation.html)
+for guidance on installing and using the provider plugin.
+
+[^vagrant-in-nix-devshell]: The [Nix development shell][] provides the
+                            `vagrant` executable and the `vagrant-libvirt`
+                            provider plugin.
+
+Vagrant provisions its machines using the [`tests/test.yml`][] playbook, which
+installs the prerequisites for running Ansible against those machines and then
+applies this Ansible role.
+
+> [!IMPORTANT]
+> If you add support for a new distribution to this Ansible role, please try to
+> add a Vagrant guest that runs this distribution, and, if necessary, update
+> [`tests/test.yml`][] to install Ansible's dependencies on this guest.
+> Additionally, please add a description of the distribution to the list above.
+
+### Just-in-time Vagrant box builds
+
+The LibreELEC and OSMC machines use custom Vagrant boxes built with scripts
+that live in this project
+([`create-libreelec-box`](/scripts/create-libreelec-box) and
+[`create-osmc-box`](/scripts/create-osmc-box), respectively).  The Vagrant
+environment is configured to build these boxes on-demand; effectively, the
+boxes are built upon `vagrant up` if they are not already installed.  This
+means that, in order to run these machines, you'll need to ensure that all
+box-building prerequisites are available on your Vagrant host
+system[^box-building-in-nix-devshell].
+
+[^box-building-in-nix-devshell]: The [Nix development shell][] provides all of
+                                 these prerequisites.
+
+#### Using OSMC under Vagrant
+
+The OSMC box requires some special handling:
+
+1. OSMC publishes images for a small number of platforms and architectures
+   ([Raspberry Pi, Vero, and Apple TV](https://osmc.tv/download/)); there are
+   no prebuilt `x86_64` images (as there are [for LibreELEC](https://archive.libreelec.tv/archive/)).
+2. The kernel included in OSMC images does not support certain modules required
+   for proper operation under [QEMU's `virt` Generic Virtual Platform](https://www.qemu.org/docs/master/system/riscv/virt.html).
+
+To avoid having to run the OSMC guest under [QEMU's Raspberry Pi board emulation](https://www.qemu.org/docs/master/system/arm/raspi.html),
+which is effective but very slow, we instead build a custom kernel and initial
+RAM disk for the `aarch64` architecture and run the guest using the `virt`
+platform.  This makes the OSMC guest run faster, but comes with some downsides:
+
+1. The kernel and initial RAM disk are built with [the NixOS module
+   system](https://nix.dev/tutorials/module-system/module-system.html), and
+   building the OSMC Vagrant box therefore requires installing and running the
+   Nix package manager.
+2. If the `libvirt` daemon runs as an unprivileged user, it may not be able to
+   load the kernel and initial RAM disk from the location under
+   [`VAGRANT_HOME`](https://developer.hashicorp.com/vagrant/docs/other/environmental-variables#vagrant_home)
+   where Vagrant extracted the `.box` file, so the OSMC box includes a
+   `Vagrantfile` that, among other things, copies the kernel and initial RAM
+   disk to a world-readable location before Vagrant boots the OSMC guest (and
+   attempts to clean up these files before Vagrant exits).
+
+> [!WARNING]
+> There is a bug in Vagrant that may cause problems on the first boot of the
+> OSMC machine.  If the first `vagrant up` (or `vagrant up osmc`) hangs or
+> crashes, please try re-running the command.
+
+## GitHub Actions suite
+
+This project uses [GitHub Actions](https://docs.github.com/en/actions) for
+automated testing.  The main workflow definition is
+[`.github/workflows/ci.yml`][].  As of this writing, the workflow applies this
+Ansible role to containers based upon the following images:
+
+1. `alpine:3`
+2. `archlinux/archlinux`
+3. `debian:11`
+4. `debian:12`
+5. `ubuntu:22.04`
+6. `ubuntu:23.04`
+
+Please ensure that the workflow succeeds when run against your branch.
+
+You can run the GitHub Actions workflow locally using
+[`act`](https://github.com/nektos/act):[^act-in-nix-devshell]
+
+[^act-in-nix-devshell]: The [Nix development shell][] provides the `act`
+                        executable.
+
+```console
+$ act -j native
+```
+
+This will run the `native` job from [`.github/workflows/ci.yml`][].
+
+> [!IMPORTANT]
+> If you add support for a new distribution to this Ansible role, please try to
+> find a Docker image that uses this distribution and add it to the list of
+> images in [`.github/workflows/ci.yml`][], and, if necessary, update
+> [`tests/test.yml`][] to install Ansible's dependencies on containers using
+> this image.  Additionally, please add the new image to the list above.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Role Variables
 [`vars/default.yml`]: vars/default.yml
 
 - `kodi_user`: the user account used for running the Kodi service on the target machine.  Default: `"kodi"`.
-- `kodi_groups`: if `kodi_user` is created by this role, it will be added to these groups.  Default: `["audio", "video", "input"]`.
+- `kodi_groups`: if `kodi_user` is created by this role, it will be added to these groups.  Entries in the list may be (a) strings (`"somegroup"`) or (b) dictionaries of the form `{"name": "someuser", "gid": 11111, "system": False}`, where `name` is the group name, `gid` is the GID, and `system` is a boolean specifying whether the group is a so-called "system" group; see `ansible-doc group` for more on the meaning of these parameters.  Note that, in the dictionary form, `gid` and `system` may be omitted.  Default: `["audio", "video", "input"]`.
 - `kodi_shell`: if `kodi_user` is created by this role, it will use this value as its login shell.  Default: `"/bin/bash"`.
 - `kodi_user_create`: whether to create the user account specified in `kodi_user`.  Default: `True` (except on LibreELEC and OSMC, where it is set to `False`).
 - `kodi_data_dir`: path to the directory storing Kodi data (addons, user data, etc.). Default: `~{{ kodi_user }}/.kodi` (the `.kodi` subdirectory of the home directory of the `kodi_user` user).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,8 @@ Role Variables
 - `kodi_weather_provider`: Hostname of the weather data provider.  Default: not defined.
 - `kodi_include_default_config`: a boolean indicating whether or not to include the variable definitions from [`vars/default.yml`][].yml).  Default: `False`.
 - `kodi_systemd_service`: the name of the systemd service running Kodi.  Default: not defined.  **This variable is deprecated**; please use `kodi_service` instead.
-- `kodi_service`: the name of the service running Kodi.  Default: not defined, except on Alpine and LibreELEC where it is set to `kodi` and on OSMC where it is set to `mediacenter`.
+- `kodi_service`: the name of the service running Kodi.  Default: not defined, except on Alpine and LibreELEC where it is set to `kodi` and on OSMC where it is set to `mediacenter`.  Note that setting this variable to `{{ none }}` or `{{ omit }}` will disable service management even on systems where it would be attempted by default.
+- `kodi_service_enabled`: whether to attempt to manage Kodi via the service specified in `kodi_service`.  By default, `True` by default on systems where `kodi_service` is defined and set to a value other than `{{ omit }}` or `{{ none }}`, and `False` otherwise.
 - `kodi_check_process_cmd`: the command to use for checking whether Kodi is currently running (Kodi must be shut off before changing its configuration).  See [the platform-specific variables files](/vars) for the values of this variable.
 - `kodi_check_process_executable`: the executable to use for running `kodi_check_process_cmd`.  See [the platform-specific variables files](/vars) for the values of this variable.
 - `kodi_query_version_cmd`: the command to use for determining the version of Kodi in use.  This command only runs if `kodi_version` is undefined.  See [the platform-specific variables files](/vars) for the values of this variable.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,8 @@ Role Variables
 - `kodi_subtitles_languages`: Comma-separated list of subtitle languages.  Default: not defined.
 - `kodi_weather_provider`: Hostname of the weather data provider.  Default: not defined.
 - `kodi_include_default_config`: a boolean indicating whether or not to include the variable definitions from [`vars/default.yml`][].yml).  Default: `False`.
-- `kodi_systemd_service`: the name of the systemd service running Kodi.  Default: not defined, except on LibreELEC where it is set to `kodi` and on OSMC where it is set to `mediacenter`.
+- `kodi_systemd_service`: the name of the systemd service running Kodi.  Default: not defined.  **This variable is deprecated**; please use `kodi_service` instead.
+- `kodi_service`: the name of the service running Kodi.  Default: not defined, except on Alpine and LibreELEC where it is set to `kodi` and on OSMC where it is set to `mediacenter`.
 - `kodi_check_process_cmd`: the command to use for checking whether Kodi is currently running (Kodi must be shut off before changing its configuration).  See [the platform-specific variables files](/vars) for the values of this variable.
 - `kodi_check_process_executable`: the executable to use for running `kodi_check_process_cmd`.  See [the platform-specific variables files](/vars) for the values of this variable.
 - `kodi_query_version_cmd`: the command to use for determining the version of Kodi in use.  This command only runs if `kodi_version` is undefined.  See [the platform-specific variables files](/vars) for the values of this variable.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ Example Playbook
     - { role: jose1711.kodi_ansible_role, kodi_language: en_US }
 ```
 
+Contributing to `jose1711.kodi-ansible-role`
+--------------------------------------------
+
+Please see [`CONTRIBUTING.md`](/CONTRIBUTING.md) for notes on contributing to
+this project.
+
 License
 -------
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,8 @@
 Vagrant.configure(2) do |config|
+  config.vm.define :alpine do |alpine|
+    alpine.vm.box = 'generic/alpine319'
+  end
+
   config.vm.define :archlinux do |archlinux|
     archlinux.vm.box = 'archlinux/archlinux'
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,19 @@
+require_relative 'vagrant/lib/vagrant/libreelec/plugin'
+
+# All boxes used below support libvirt; the LibreELEC and OSMC boxes *only*
+# support libvirt.
+ENV['VAGRANT_DEFAULT_PROVIDER'] = 'libvirt'
+
+# If possible, tie on-demand box building to box addition events; otherwise,
+# perform builds on `vagrant up`.
+def trigger_box_build(config, &block)
+  if Vagrant.version?(">= 2.4.0") || ENV.fetch('VAGRANT_EXPERIMENTAL', '').split(/,/).include?('typed_triggers')
+    config.trigger.before(%I[Vagrant::Action::Builtin::BoxAdd Vagrant::Action::Building::HandleBox], type: :action, &block)
+  else
+    config.trigger.before(:up, &block)
+  end
+end
+
 Vagrant.configure(2) do |config|
   config.vm.provider :libvirt do |domain|
     # Listen on all addresses
@@ -18,6 +34,56 @@ Vagrant.configure(2) do |config|
 
   config.vm.define :ubuntu do |ubuntu|
     ubuntu.vm.box = 'generic/ubuntu2204'
+  end
+
+  config.vm.define :libreelec do |libreelec|
+    box = File.expand_path('tmp/libreelec/LibreELEC-Generic.x86_64-11.0.6.box', __dir__)
+
+    trigger_box_build(libreelec) do |t|
+      t.name = 'Create LibreELEC box'
+      t.info = "Ensuring that the LibreELEC box at #{box.inspect} exists"
+      unless File.exist?(box)
+        t.run = {
+          path: File.expand_path('scripts/create-libreelec-box', __dir__),
+          args: [box],
+        }
+      end
+    end
+
+    libreelec.vm.box_url = "file://#{box}"
+    libreelec.vm.box = 'libreelec'
+  end
+
+  config.vm.define :osmc do |osmc|
+    box = File.expand_path('tmp/osmc/OSMC_TGT_rbp4_20240205.box', __dir__)
+
+    trigger_box_build(osmc) do |t|
+      t.name = 'Create OSMC box'
+      t.info = "Ensuring that the OSMC box at #{box.inspect} exists"
+      t.warn = <<~WARN.gsub(/(?<!^)\n/, ' ')
+        The `osmc` box's Vagrantfile defines a Vagrant trigger that installs a
+        custom kernel and initial ramdisk to a location accessible to the libvirt daemon.
+
+        This trigger *must* run in order to boot machines using the `osmc` box.
+
+        A bug in Vagrant prevents triggers defined in a box's Vagrantfile from
+        running when the box is first added; see https://github.com/hashicorp/vagrant/issues/11901.
+
+        If your OSMC virtual machine hangs upon boot, or if Vagrant crashes
+        bringing up the OSMC virtual machine, please try running `vagrant up` a
+        second time, as Vagrant will then properly execute the `up` trigger
+        mentioned above.
+      WARN
+      unless File.exist?(box)
+        t.run = {
+          path: File.expand_path('scripts/create-osmc-box', __dir__),
+          args: [box],
+        }
+      end
+    end
+
+    osmc.vm.box_url = "file://#{box}"
+    osmc.vm.box = 'osmc'
   end
 
   config.vm.provision :ansible, type: 'ansible' do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,9 @@
 Vagrant.configure(2) do |config|
+  config.vm.provider :libvirt do |domain|
+    # Listen on all addresses
+    domain.graphics_ip = '::'
+  end
+
   config.vm.define :alpine do |alpine|
     alpine.vm.box = 'generic/alpine319'
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,11 @@ def trigger_box_build(config, &block)
 end
 
 Vagrant.configure(2) do |config|
+  # We don't need to sync this folder onto the guest, and disabling the synced
+  # folder prevents Vagrant from bailing out on guests that lack `rsync` (e.g.
+  # LibreELEC).
+  config.vm.synced_folder '.', '/vagrant', disabled: true
+
   config.vm.provider :libvirt do |domain|
     # Listen on all addresses
     domain.graphics_ip = '::'

--- a/compat.nix
+++ b/compat.nix
@@ -1,0 +1,26 @@
+let
+  haveFlakeLock = builtins.pathExists ./flake.lock;
+
+  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+
+  ref =
+    if haveFlakeLock
+    then lock.nodes.flake-compat.locked.rev
+    else "master";
+
+  checksum =
+    if haveFlakeLock
+    then {
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+    else {};
+
+  args =
+    {
+      url = "https://github.com/edolstra/flake-compat/archive/${ref}.tar.gz";
+    }
+    // checksum;
+
+  flakeCompat = fetchTarball args;
+in
+  import flakeCompat {src = ./.;}

--- a/configuration.nix
+++ b/configuration.nix
@@ -1,0 +1,42 @@
+{
+  config,
+  lib,
+  modulesPath,
+  ...
+}: {
+  imports = [
+    "${toString modulesPath}/profiles/qemu-guest.nix"
+  ];
+
+  boot.consoleLogLevel = 8;
+
+  boot.initrd.systemd.enable = true;
+
+  # The serial ports listed here are:
+  # - ttyS0: for Tegra (Jetson TX1)
+  # - ttyAMA0: for QEMU's -machine virt
+  boot.kernelParams = [
+    "console=tty0"
+    "console=ttyAMA0,115200n8"
+    "console=ttyS0,115200n8"
+  ];
+
+  boot.loader.grub.enable = false;
+  boot.loader.generic-extlinux-compatible.enable = true;
+
+  console.earlySetup = true;
+
+  fileSystems."/" = {
+    fsType = "ext4";
+    device = "/dev/disk/by-label/osmc";
+  };
+
+  hardware.enableRedistributableFirmware = true;
+
+  networking.hostName = "osmc";
+  networking.wireless.enable = false;
+
+  system.stateVersion = "23.11";
+
+  users.users.root.password = "osmc";
+}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,1 @@
+(import ./compat.nix).defaultNix

--- a/files/start_kodi.sh
+++ b/files/start_kodi.sh
@@ -10,4 +10,5 @@ pid="$!"
 echo "$pid"
 
 # Try to disown the process, but do not exit with nonzero status if this fails.
-disown "$pid" 1>/dev/null || :
+# shellcheck disable=SC3044
+disown "$pid" 1>/dev/null 2>&1 || :

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,156 @@
+{
+  "nodes": {
+    "devshell": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1705332421,
+        "narHash": "sha256-USpGLPme1IuqG78JNqSaRabilwkCyHmVWY0M9vYyqEA=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "83cb93d6d063ad290beee669f4badf9914cc16ec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1707347730,
+        "narHash": "sha256-0etC/exQIaqC9vliKhc3eZE2Mm2wgLa0tj93ZF/egvM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "6832d0d99649db3d65a0e15fa51471537b2c56a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "devshell": "devshell",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1707300477,
+        "narHash": "sha256-qQF0fEkHlnxHcrKIMRzOETnRBksUK048MXkX0SOmxvA=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "ac599dab59a66304eb511af07b3883114f061b9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,139 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    devshell.url = "github:numtide/devshell";
+    devshell.inputs.nixpkgs.follows = "nixpkgs";
+    flake-compat.url = "github:edolstra/flake-compat";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake {inherit inputs;} ({inputs, ...}: {
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+
+      imports = [
+        inputs.devshell.flakeModule
+        inputs.treefmt-nix.flakeModule
+      ];
+
+      perSystem = {
+        config,
+        lib,
+        pkgs,
+        system,
+        ...
+      }: {
+        devshells.default = {
+          commands = [
+            {
+              category = "dev";
+              package = pkgs.ansible;
+            }
+
+            {
+              category = "dev";
+              package = pkgs.vagrant.override {
+                # So that we can use `libguestfs-with-appliance` when calling
+                # `create-box` (by default, the `vagrant` derivation depends on
+                # plain old `libguestfs`).
+                libguestfs = pkgs.libguestfs-with-appliance;
+              };
+            }
+
+            {
+              category = "dev";
+              package = config.packages.vagrant-libvirt-create-box;
+            }
+
+            {
+              name = "fmt";
+              category = "dev";
+              help = "Format this project's code";
+              command = ''
+                exec ${config.treefmt.build.wrapper}/bin/treefmt "$@"
+              '';
+            }
+          ];
+
+          devshell.packages = with pkgs; [
+            curl
+            guestfs-tools
+            gzip
+            libguestfs-with-appliance
+            qemu
+            sshpass # for password auth with Ansible
+          ];
+        };
+
+        packages = let
+          rpi4 = inputs.nixpkgs.lib.nixosSystem {
+            inherit system;
+
+            modules = [
+              {
+                nixpkgs.crossSystem.system = "aarch64-linux";
+              }
+              ./configuration.nix
+            ];
+          };
+        in {
+          rpi4-initrd = rpi4.config.system.build.initialRamdisk;
+          rpi4-kernel = rpi4.config.system.build.kernel;
+
+          # From the `vagrant-libvirt` project.  Patched to permit injecting
+          # additional files into the generated Vagrant box archive.
+          vagrant-libvirt-create-box =
+            pkgs.runCommand "vagrant-libvirt-create-box" {
+              src = pkgs.fetchurl {
+                url = "https://raw.githubusercontent.com/vagrant-libvirt/vagrant-libvirt/main/tools/create_box.sh";
+                sha256 = "sha256-xrCoMeXV++Dmi766r0i0RO4NMe7LDr3jNdJSXjNrY+4=";
+              };
+
+              nativeBuildInputs = with pkgs; [
+                makeWrapper
+              ];
+
+              meta = {
+                mainProgram = "vagrant-libvirt-create-box";
+                description = "create a Vagrant box file from a qcow2 disk image";
+              };
+            } ''
+              script="''${out}/bin/vagrant-libvirt-create-box"
+              install -D "$src" "$script"
+              sed -i -e '/^tar[[:space:]]\+cv/ {
+                s/^tar\([[:space:]]\+\)/tar --transform="s|.*\/||"\1-/
+                s/\([[:space:]]\+\)|\([[:space:]]\+\)/\1"$@" |\2/
+                s/^/argc="$#"; if [ "$argc" -ge 3 ]; then shift 3; elif [ "$argc" -eq 2 ]; then shift 2; else shift 1; fi; /
+              }' "$script"
+              wrapProgram "$script" --prefix PATH : ${lib.makeBinPath (with pkgs; [coreutils gawk gnutar pigz psmisc qemu])}
+            '';
+        };
+
+        treefmt = {
+          programs.alejandra.enable = true;
+          flakeFormatter = true;
+          projectRootFile = "flake.nix";
+        };
+      };
+
+      flake = {
+        nixosConfigurations = {
+          rpi4 = inputs.nixpkgs.lib.nixosSystem {
+            system = "aarch64-linux";
+            modules = [
+              ./configuration.nix
+            ];
+          };
+        };
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,13 @@
       }: {
         devshells.default = {
           commands = [
+            # Local GitHub actions runner.  Run `act -j native` to execute the
+            # `native` job.
+            {
+              category = "dev";
+              package = pkgs.act;
+            }
+
             {
               category = "dev";
               package = pkgs.ansible;

--- a/scripts/create-box
+++ b/scripts/create-box
@@ -1,0 +1,115 @@
+#!/bin/sh
+
+PS4='+ ${BASH_SOURCE:-${0}}@${LINENO:-0}${FUNCNAME:+#${FUNCNAME}()}: '
+
+set -eu
+
+looks_like_toplevel() {
+    [ -d "${1?}/vagrant/share" ]
+}
+
+if ! toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || ! looks_like_toplevel "$toplevel"; then
+    if ! toplevel="$(readlink -f "${0%/*}")" || ! looks_like_toplevel "$toplevel"; then
+        if ! toplevel="${PWD:-$(pwd 2>/dev/null)}" || ! looks_like_toplevel "$toplevel"; then
+            if ! toplevel=. || ! looks_like_toplevel "$toplevel"; then
+                exit 75
+            fi
+        fi
+    fi
+fi
+
+box="${1:?please specify a box name or path}"
+
+case "$box" in
+    */*)
+        box="$({ realpath -m "$box" || readlink -m "$box" ; } 2>/dev/null)"
+        dir="${box%/*}"
+        box_name="${box##*/}"
+        ;;
+    *)
+        dir="${toplevel}/tmp"
+        box_name="$box"
+        box="${dir}/${box_name}"
+        ;;
+esac
+
+cleanup() {
+    if [ -n "${tmpdir:-}" ]; then
+        rm -rf --one-file-system --preserve-root "$tmpdir" 2>/dev/null || rm -rf "$tmpdir"
+    fi
+}
+
+trap cleanup INT TERM QUIT EXIT
+
+mkdir -p "$dir"
+
+tmpdir="$(mktemp -d "${dir}/.${0##*/}.XXXXXXXXXX")"
+cd "$tmpdir"
+
+name="${box_name%.box}"
+img_archive_url="${2:-"${CREATE_BOX_IMG_ARCHIVE_BASEURL:?please specify an image archive URL or base URL}/${name}.img.gz"}"
+img_archive="${img_archive_url##*/}"
+img="${img_archive%.gz}"
+disk="${img%.img}.qcow2"
+shrunk="${disk%.qcow2}.shrunk.qcow2"
+
+vagrant_keys_url='https://raw.githubusercontent.com/hashicorp/vagrant/main/keys/vagrant.pub'
+vagrant_keys="${vagrant_keys_url##*/}"
+
+prepare_qcow2() {
+    if format="$(qemu-img info --output=json "$img" | jq --raw-output .format)" && [ "$format" != qcow2 ]; then
+        qemu-img convert -f "$format" -O qcow2 "$img" "$disk"
+    else
+        mv -f "$img" "$disk"
+    fi
+
+    qemu-img convert -f qcow2 -O qcow2 "$disk" "$shrunk"
+
+    qemu-img resize "$shrunk" 2G
+}
+
+case "$img_archive_url" in
+    *://*)
+        curl -fsSLo "$img_archive" "$img_archive_url"
+        gunzip -f "$img_archive"
+        ;;
+    *.gz)
+        gunzip -f "$img_archive"
+        ;;
+    *)
+        if [ -e "$img_archive_url" ]; then
+            mv -f "$img_archive_url" "$img"
+        else
+            prepare_qcow2() {
+                qemu-img create -f qcow2 "$shrunk" 2G
+            }
+        fi
+        ;;
+esac
+
+prepare_qcow2
+
+curl -fsSLO "$vagrant_keys_url"
+
+if ! [ -t 0 ]; then
+    awk -v name="$name" -v toplevel="$toplevel" -v vagrant_keys="$vagrant_keys" '{
+        gsub(/@name@/, name);
+        gsub(/@toplevel@/, toplevel);
+        gsub(/@vagrant_keys@/, vagrant_keys);
+        print;
+    }' | guestfish --rw -a "$shrunk"
+fi
+
+stty sane 1>/dev/null 2>&1 || :
+
+rm -f "${shrunk%.qcow2}.box" "$box_name" "$vagrant_keys" "$disk" "$img"
+
+# `xargs`, rather than `find ... -exec`, to ensure we run
+# `vagrant-libvirt-create-box` even if no files other than `"$shrunk"` were
+# found.
+find "${PWD:-$(pwd)}" -type f -a '!' -name "$shrunk" -print0 \
+    | xargs -0 "${SHELL:-/bin/sh}" vagrant-libvirt-create-box "$shrunk" "$box_name" "${3:-/dev/null}"
+
+rm -f "$shrunk"
+
+install -D "$box_name" "$box"

--- a/scripts/create-libreelec-box
+++ b/scripts/create-libreelec-box
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+set -eu
+
+box="${1:-LibreELEC-Generic.x86_64-11.0.6.box}"
+shift 2>/dev/null || :
+
+vagrantfile_add_rel="${0%/*}/../vagrant/share/libreelec/Vagrantfile"
+vagrantfile_add="$({ realpath "$vagrantfile_add_rel" || readlink -f "$vagrantfile_add_rel" ; } 2>/dev/null)"
+
+export CREATE_BOX_IMG_ARCHIVE_BASEURL="${CREATE_BOX_IMG_ARCHIVE_BASEURL:-https://archive.libreelec.tv/archive}"
+
+# 1. Resize the partition meant for `/storage` to the maximum possible extent.
+#    Through experimentation, it looks like we cannot resize to anything beyond
+#    the 34th-from-last sector (presumably this is where the GPT data
+#    structures live).
+# 2. Mount the image, then mount the `SYSTEM` squashfs, then mount the `/flash`
+#    volume and `/storage` volume.
+# 3. Add the Vagrant insecure (bootstrap) public keys to the `root` user's
+#    authorized keys file.
+# 4. Add the override file for the `kodi.service` system unit; the changes
+#    wrought by this override file will prevent LibreELEC from rebooting in
+#    case `kodi.service` restarts "too many" times.
+# 5. Add the `kodi.conf` file that makes Kodi run in headless mode.
+# 6. Edit the bootloader files.
+# 7. Finally, unmount everything and exit.
+exec "${0%/*}/create-box" "$box" "" "$vagrantfile_add" "$@" <<'GUESTFISH_PROGRAM'
+run
+
+part-expand-gpt /dev/sda
+part-resize /dev/sda 2 -34
+resize2fs /dev/sda2
+
+mkmountpoint /img
+mkmountpoint /sqsh
+mount /dev/sda1 /img
+mount-loop /img/SYSTEM /sqsh
+mount /dev/sda1 /sqsh/flash
+mount /dev/sda2 /sqsh/storage
+
+mkdir-p /sqsh/storage/.ssh
+chown 0 0 /sqsh/storage/.ssh
+chmod 0700 /sqsh/storage/.ssh
+
+upload @vagrant_keys@ /sqsh/storage/.ssh/authorized_keys
+chmod 0600 /sqsh/storage/.ssh/authorized_keys
+chown 0 0 /sqsh/storage/.ssh/authorized_keys
+
+mkdir-p /sqsh/storage/.config/system.d/kodi.service.d
+upload @toplevel@/vagrant/share/libreelec/kodi.service.d.override.conf /sqsh/storage/.config/system.d/kodi.service.d/override.conf
+chmod 0644 /sqsh/storage/.config/system.d/kodi.service.d/override.conf
+chown 0 0 /sqsh/storage/.config/system.d/kodi.service.d/override.conf
+
+upload @toplevel@/vagrant/share/libreelec/kodi.conf /sqsh/storage/.config/kodi.conf
+chmod 0644 /sqsh/storage/.config/kodi.conf
+chown 0 0 /sqsh/storage/.config/kodi.conf
+
+download /sqsh/flash/syslinux.cfg syslinux.cfg
+! sed -i -e 's/^DEFAULT.*/DEFAULT run/' -e '/^[[:space:]]*APPEND/ { s/$/ ssh/ }' syslinux.cfg
+upload syslinux.cfg /sqsh/flash/syslinux.cfg
+! rm -f syslinux.cfg
+
+download /sqsh/flash/EFI/BOOT/grub.cfg grub.cfg
+! sed -i -e 's/\(^set[[:space:]]\+default="\)[^"]*/\1Run/' -e '/^[[:space:]]*linux/ { s/$/ ssh/ }' grub.cfg
+upload grub.cfg /sqsh/flash/EFI/BOOT/grub.cfg
+! rm -f grub.cfg
+
+umount /sqsh/flash
+umount /sqsh/storage
+umount /sqsh
+umount /img
+GUESTFISH_PROGRAM

--- a/scripts/create-osmc-box
+++ b/scripts/create-osmc-box
@@ -1,0 +1,66 @@
+#!/bin/sh
+
+set -eu
+
+box="${1:-OSMC_TGT_rbp4_20240205.box}"
+shift 2>/dev/null || :
+
+vagrantfile_add_rel="${0%/*}/../vagrant/share/osmc/Vagrantfile"
+vagrantfile_add="$({ realpath "$vagrantfile_add_rel" || readlink -f "$vagrantfile_add_rel" ; } 2>/dev/null)"
+
+date="${box##*_}"
+date="${date%%.*}"
+date="${date:-20240205}"
+
+download_url=https://ftp.fau.de/osmc/osmc/download
+export CREATE_BOX_IMG_ARCHIVE_BASEURL="${CREATE_BOX_IMG_ARCHIVE_BASEURL:-"${download_url}/installers/diskimages"}"
+
+# 1. Create a partition, format it `ext4`, and mount it at `/`.
+# 2. Download and extract the OSMC root filesystem onto the newly-created root
+#    partition.
+# 3. Add the Vagrant insecure (bootstrap) public keys to the `root` user's
+#    authorized keys file.
+# 4. Fix the upstream `90-rpi-add-serial.rules` udev rules file; without this,
+#    udev complains about "invalid substitution type" due to the use of
+#    unescaped `$` uses in shell commands (see, e.g.,
+#    https://askubuntu.com/questions/1420933/invalid-value-for-import-invalid-substitution-type)
+# 5. Remove a shell profile script that runs `apt-get update` upon login (gives
+#    logins a speed boost).
+# 6. Remove the `udisks-glue` service ("mount disks automatically with
+#    standby") from `multi-user.target.wants` so that it does not start
+#    automatically; this service always fails at the `ExecStartPre` stage, and
+#    we don't need automatic disk mounting anyway.
+# 7. Build the kernel and initrd.
+exec "${0%/*}/create-box" "$box" "${box%.box}.img" "$vagrantfile_add" "$@" <<GUESTFISH_PROGRAM
+run
+
+part-disk /dev/sda mbr
+mkfs ext4 /dev/sda1 label:osmc
+mount /dev/sda1 /
+
+! curl -fsSLo filesystem.tar.xz ${download_url}/filesystems/osmc-rbp4-filesystem-${date}.tar.xz
+tar-in filesystem.tar.xz / compress:xz
+! rm -f filesystem.tar.xz
+
+mkdir-p /home/osmc/.ssh
+chown 1000 1000 /home/osmc/.ssh
+chmod 0700 /home/osmc/.ssh
+
+upload @vagrant_keys@ /home/osmc/.ssh/authorized_keys
+chmod 0600 /home/osmc/.ssh/authorized_keys
+chown 1000 1000 /home/osmc/.ssh/authorized_keys
+
+mkdir-p /etc/udev/rules.d
+upload @toplevel@/vagrant/share/osmc/90-rpi-add-serial.rules /etc/udev/rules.d/90-rpi-add-serial.rules
+chmod 0644 /etc/udev/rules.d/90-rpi-add-serial.rules
+chown 0 0 /etc/udev/rules.d/90-rpi-add-serial.rules
+
+rm-f /etc/profile.d/101-apt-update.sh
+
+rm-f /etc/systemd/system/multi-user.target.wants/udisks-glue.service
+
+unmount /
+
+! cp -f "\$(nix --extra-experimental-features 'flakes nix-command' build -L --no-link --print-out-paths '.#rpi4-kernel')/Image" kernel
+! cp -f "\$(nix --extra-experimental-features 'flakes nix-command' build -L --no-link --print-out-paths '.#rpi4-initrd')/initrd" initrd
+GUESTFISH_PROGRAM

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./compat.nix).shellNix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,10 +78,24 @@
   - configure
   - get_addons
 
+- when: "kodi_systemd_service is defined"
+  block:
+  - name: "Issue warning about variable deprecation"
+    debug:
+      msg: "`kodi_systemd_service` is deprecated; please use `kodi_service` instead"
+  - name: "Check that we are not going to overwrite `kodi_service`"
+    assert:
+      that:
+        - "(kodi_service is not defined) or  (kodi_service == kodi_systemd_service)"
+      msg: "`kodi_service` and `kodi_systemd_service` have conflicting definitions; please define only `kodi_service`"
+  - name: "Set kodi_service variable"
+    set_fact:
+      kodi_service: "{{ kodi_systemd_service }}"
+
 # changing Kodi configuration while Kodi is running is
 # not supported so let's make sure it's stopped before we
 # continue
-- when: "kodi_systemd_service is defined"
+- when: "kodi_service is defined"
   block:
   # Ensure the service is started so that Kodi populates the addon database and
   # performs other setup that may be required by addon installation and
@@ -90,7 +104,7 @@
     block:
     - name: Start Kodi via service
       service:
-        name: "{{ kodi_systemd_service }}"
+        name: "{{ kodi_service }}"
         state: started
       register: kodi_start
       ignore_errors: True
@@ -108,12 +122,12 @@
 
   - name: Stop Kodi via service
     service:
-      name: "{{ kodi_systemd_service }}"
+      name: "{{ kodi_service }}"
       state: stopped
     tags:
     - configure
 
-- when: "kodi_systemd_service is not defined"
+- when: "kodi_service is not defined"
   block:
   - name: Ensure that Kodi process-checking variables are defined
     assert:
@@ -388,8 +402,8 @@
 
 - name: Start Kodi via service
   service:
-    name: "{{ kodi_systemd_service }}"
+    name: "{{ kodi_service }}"
     state: started
-  when: "kodi_systemd_service is defined"
+  when: "kodi_service is defined"
   tags:
   - configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -57,6 +57,19 @@
   - install
   - get_addons
 
+# The default value of `kodi_groups` is `["audio", "video", "input"]`.  On
+# explicitly-supported distributions, all of these groups are usually present
+# on a base/stock installation.  Exception: on Debian and Ubuntu, the `input`
+# group is created by the post-installation script from the `udev` package,
+# and the `udev` package is not installed by default in at least some Debian
+# and Ubuntu container images.  So, ensure that the groups are created.
+- name: "Create Kodi groups"
+  group:
+    name: "{{ item }}"
+    state: present
+    system: True
+  with_items: "{{ kodi_groups }}"
+
 - name: Create Kodi user
   user:
     name: "{{ kodi_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,7 +78,18 @@
   - configure
   - get_addons
 
-- when: "kodi_systemd_service is defined"
+- name: "determine whether to manage Kodi as a service"
+  set_fact:
+    kodi_service_enabled: '{{
+        kodi_service_enabled
+      | default((kodi_service is defined) and (kodi_service is not none) and (kodi_service != omit))
+    }}'
+    kodi_systemd_service_enabled: '{{
+          kodi_systemd_service_enabled
+        | default((kodi_systemd_service is defined) and (kodi_systemd_service is not none) and (kodi_systemd_service != omit))
+    }}'
+
+- when: "kodi_systemd_service_enabled"
   block:
   - name: "Issue warning about variable deprecation"
     debug:
@@ -86,16 +97,17 @@
   - name: "Check that we are not going to overwrite `kodi_service`"
     assert:
       that:
-        - "(kodi_service is not defined) or  (kodi_service == kodi_systemd_service)"
+        - "(kodi_service is not defined) or (kodi_service == kodi_systemd_service)"
       msg: "`kodi_service` and `kodi_systemd_service` have conflicting definitions; please define only `kodi_service`"
   - name: "Set kodi_service variable"
     set_fact:
       kodi_service: "{{ kodi_systemd_service }}"
+      kodi_service_enabled: "{{ kodi_systemd_service_enabled }}"
 
 # changing Kodi configuration while Kodi is running is
 # not supported so let's make sure it's stopped before we
 # continue
-- when: "kodi_service is defined"
+- when: "kodi_service_enabled | bool"
   block:
   # Ensure the service is started so that Kodi populates the addon database and
   # performs other setup that may be required by addon installation and
@@ -104,7 +116,7 @@
     block:
     - name: Start Kodi via service
       service:
-        name: "{{ kodi_service }}"
+        name: "{{ kodi_service | default(omit) }}"
         state: started
       register: kodi_start
       ignore_errors: True
@@ -122,12 +134,12 @@
 
   - name: Stop Kodi via service
     service:
-      name: "{{ kodi_service }}"
+      name: "{{ kodi_service | default(omit) }}"
       state: stopped
     tags:
     - configure
 
-- when: "kodi_service is not defined"
+- when: "not (kodi_service_enabled | bool)"
   block:
   - name: Ensure that Kodi process-checking variables are defined
     assert:
@@ -402,8 +414,8 @@
 
 - name: Start Kodi via service
   service:
-    name: "{{ kodi_service }}"
+    name: "{{ kodi_service | default(omit) }}"
     state: started
-  when: "kodi_service is defined"
+  when: "kodi_service_enabled | bool"
   tags:
   - configure

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -63,11 +63,17 @@
 # group is created by the post-installation script from the `udev` package,
 # and the `udev` package is not installed by default in at least some Debian
 # and Ubuntu container images.  So, ensure that the groups are created.
+#
+# Handles both:
+#   1. `"foogroup"`, and
+#   2. `{"name": "foogroup", "gid": 999, "system": False}`
+# Plus degenerate cases of `2` (e.g. no `gid` or `system` attribute specified).
 - name: "Create Kodi groups"
   group:
-    name: "{{ item }}"
+    name: "{{ (item is mapping) | ternary((item.name | default(omit)), item) }}"
     state: present
-    system: True
+    system: "{{ (item is mapping) | ternary((item.system | default(True) | bool), True) }}"
+    gid: "{{ (item is mapping) | ternary((item.gid | default(omit)), omit) }}"
   with_items: "{{ kodi_groups }}"
 
 - name: Create Kodi user

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -113,8 +113,8 @@
       - get_addons
 
     - name: Let Kodi run for a bit
-      pause:
-        seconds: "{{ kodi_start_seconds | int }}"
+      wait_for:
+        timeout: "{{ kodi_start_seconds | default(10) | int }}"
       when: 'kodi_start is changed'
       tags:
       - configure
@@ -167,8 +167,8 @@
       check_mode: no
 
     - name: Let Kodi run for a bit
-      pause:
-        seconds: "{{ kodi_start_seconds | default(10) | int }}"
+      wait_for:
+        timeout: "{{ kodi_start_seconds | default(10) | int }}"
       tags:
       - configure
       - get_addons

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,7 +89,7 @@
   - when: "kodi_attempt_start | bool"
     block:
     - name: Start Kodi via service
-      systemd:
+      service:
         name: "{{ kodi_systemd_service }}"
         state: started
       register: kodi_start
@@ -107,7 +107,7 @@
       - get_addons
 
   - name: Stop Kodi via service
-    systemd:
+    service:
       name: "{{ kodi_systemd_service }}"
       state: stopped
     tags:
@@ -387,7 +387,7 @@
   tags: transfer_feeds
 
 - name: Start Kodi via service
-  systemd:
+  service:
     name: "{{ kodi_systemd_service }}"
     state: started
   when: "kodi_systemd_service is defined"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -22,10 +22,13 @@
       # package, so we have to install `kodi-inputstream-adaptive`.
       # Re `acl`: https://github.com/ansible/ansible/issues/74830#issuecomment-848817825
       raw: |
+        export DEBIAN_FRONTEND=noninteractive
+        echo 'tzdata tzdata/Areas select Europe' | debconf-set-selections || exit
+        echo 'tzdata tzdata/Zones/Europe select Bratislava' | debconf-set-selections || exit
         if command -v mediacenter 1>/dev/null 2>&1; then
-          apt -y update && { apt -y install python3 || apt -y install python; };
+          apt -y update && { apt -y install --no-install-recommends python3 || apt -y install --no-install-recommends python; };
         else
-          apt -y update && { apt -y install python3 kodi-inputstream-adaptive || apt -y install python kodi-inputstream-adaptive; };
+          apt -y update && { apt -y install --no-install-recommends python3 kodi-inputstream-adaptive || apt -y install python kodi-inputstream-adaptive; };
         fi
       ignore_errors: True
       tags: always

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -21,7 +21,12 @@
       # NOTE that `kodi-inputstream-adaptive` does not ship with the base Kodi
       # package, so we have to install `kodi-inputstream-adaptive`.
       # Re `acl`: https://github.com/ansible/ansible/issues/74830#issuecomment-848817825
-      raw: 'apt -y update && { apt -y install python3 kodi-inputstream-adaptive || apt -y install python kodi-inputstream-adaptive; }'
+      raw: |
+        if command -v mediacenter 1>/dev/null 2>&1; then
+          apt -y update && { apt -y install python3 || apt -y install python; };
+        else
+          apt -y update && { apt -y install python3 kodi-inputstream-adaptive || apt -y install python kodi-inputstream-adaptive; };
+        fi
       ignore_errors: True
       tags: always
 
@@ -49,6 +54,11 @@
           - 'jellyfin_cached=https://repo.jellyfin.org/releases/client/kodi/addons.xml'
           - 'sandmann79_cached=https://raw.githubusercontent.com/Sandmann79/xbmc/master/packages/addons.xml'
           - 'sandmann79_py3_cached=https://raw.githubusercontent.com/Sandmann79/xbmc/master/packages-py3/addons.xml'
+          # XXX we include this repository for all target machines, but it will
+          # only work for LibreELEC machines.  This should be okay, as the only
+          # addons we need from this repository should already be present on
+          # non-LibreELEC hosts (e.g. the `inputstream.adaptive` addon).
+          - 'libreelec_cached=https://addons.libreelec.tv/11.80.4/Generic/x86_64/addons.xml.gz'
         kodi_config:
           - file: 'userdata/guisettings.xml'
             key: 'settings/setting[@id="input.libinputkeyboardlayout"]'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,6 +4,11 @@
   become: True
   gather_facts: False
   tasks:
+    - name: 'test | install dependencies with apk'
+      raw: 'apk add -U python3 && apk add -U kodi-inputstream-adaptive --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing/'
+      ignore_errors: True
+      tags: always
+
     - name: 'test | install python with pacman'
       # https://wiki.archlinux.org/title/Pacman/Package_signing#Upgrade_system_regularly
       # NOTE that `kodi-inputstream-adaptive` does not ship with the base Kodi

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -25,7 +25,6 @@
       ignore_errors: True
       tags: always
 
-
 - hosts: all
   become: True
   roles:

--- a/tmp/.gitignore
+++ b/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,3 @@
+# `vagrant-libreelec`
+
+Support for LibreELEC Vagrant guests.  Just enough to make Vagrant happy :).

--- a/vagrant/lib/vagrant/libreelec.rb
+++ b/vagrant/lib/vagrant/libreelec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require_relative "libreelec/version"
+
+module VagrantPlugins
+  module LibreELEC
+  end
+end

--- a/vagrant/lib/vagrant/libreelec/guest.rb
+++ b/vagrant/lib/vagrant/libreelec/guest.rb
@@ -1,0 +1,14 @@
+require 'vagrant'
+require File.expand_path('plugins/guests/linux/guest', Vagrant.source_root)
+
+module VagrantPlugins
+  module LibreELEC
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # `VagrantPlugins::GuestLinux::Guest#detect?` tests the value of this
+      # constant against (among other things) the value of the `ID` variable in
+      # `/etc/os-release`.  For LibreELEC, the correct value is the string
+      # "libreelec".
+      GUEST_DETECTION_NAME = 'libreelec'.freeze
+    end
+  end
+end

--- a/vagrant/lib/vagrant/libreelec/plugin.rb
+++ b/vagrant/lib/vagrant/libreelec/plugin.rb
@@ -1,5 +1,4 @@
 require 'vagrant'
-require File.expand_path('plugins/guests/debian/plugin', Vagrant.source_root)
 
 module VagrantPlugins
   module LibreELEC
@@ -15,7 +14,15 @@ module VagrantPlugins
       end
 
       guest_capability(GUEST_NAME, :change_host_name) do
+        require File.expand_path('plugins/guests/debian/plugin', Vagrant.source_root)
         VagrantPlugins::GuestDebian::ChangeHostName
+      end
+
+      # `/etc/fstab` exists in the LibreELEC guest but is not writable (it's on
+      # the squashfs partition).  Stop Vagrant from trying to write to the file
+      # by nil-ifying the relevant guest capability.
+      guest_capability(GUEST_NAME, :persist_mount_shared_folder) do
+        nil
       end
     end
   end

--- a/vagrant/lib/vagrant/libreelec/plugin.rb
+++ b/vagrant/lib/vagrant/libreelec/plugin.rb
@@ -1,0 +1,22 @@
+require 'vagrant'
+require File.expand_path('plugins/guests/debian/plugin', Vagrant.source_root)
+
+module VagrantPlugins
+  module LibreELEC
+    class Plugin < Vagrant.plugin(2)
+      GUEST_NAME = :libreelec
+
+      name 'LibreELEC guest'
+      description 'LibreELEC guest support'
+
+      guest(GUEST_NAME, :linux) do
+        require_relative 'guest'
+        Guest
+      end
+
+      guest_capability(GUEST_NAME, :change_host_name) do
+        VagrantPlugins::GuestDebian::ChangeHostName
+      end
+    end
+  end
+end

--- a/vagrant/lib/vagrant/libreelec/version.rb
+++ b/vagrant/lib/vagrant/libreelec/version.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Vagrant
+  module LibreELEC
+    VERSION = '0.1.0'
+  end
+end

--- a/vagrant/share/libreelec/Vagrantfile
+++ b/vagrant/share/libreelec/Vagrantfile
@@ -1,0 +1,9 @@
+  config.ssh.username = 'root'
+  config.ssh.password = 'libreelec'
+
+  config.vm.boot_timeout = 1800
+
+  config.vm.provider :libvirt do |domain|
+    domain.cpus = 2
+    domain.memory = 2048
+  end

--- a/vagrant/share/libreelec/kodi.conf
+++ b/vagrant/share/libreelec/kodi.conf
@@ -1,0 +1,3 @@
+# Run in headless mode to prevent Kodi from bailing out because it cannot start
+# its GUI
+KODI_ARGS='--headless'

--- a/vagrant/share/libreelec/kodi.service.d.override.conf
+++ b/vagrant/share/libreelec/kodi.service.d.override.conf
@@ -1,0 +1,12 @@
+[Service]
+# disable "upstream" `ExecStartPost` stanzas, including the one that
+# reboots the machine if `kodi.service` exits.
+ExecStartPost=
+
+[Unit]
+StartAction=
+StartAction=none
+FailureAction=
+FailureAction=none
+StartLimitAction=
+StartLimitAction=none

--- a/vagrant/share/osmc/90-rpi-add-serial.rules
+++ b/vagrant/share/osmc/90-rpi-add-serial.rules
@@ -1,0 +1,19 @@
+KERNEL=="ttyAMA[01]", PROGRAM="/bin/sh -c '\
+        if cmp -s /proc/device-tree/aliases/uart0 /proc/device-tree-aliases/serial0; then \
+            echo 0;\
+        elif cmp -s /proc/device-tree/aliases/uart0 /proc/device-tree-aliases/serial1; then \
+            echo 1; \
+        else \
+            exit 1; \
+        fi\
+    '", SYMLINK+="serial%c"
+
+KERNEL=="ttyS0", PROGRAM="/bin/sh -c '\
+        if cmp -s /proc/device-tree/aliases/uart1 /proc/device-tree-aliases/serial0; then \
+            echo 0;\
+        elif cmp -s /proc/device-tree/aliases/uart1 /proc/device-tree-aliases/serial1; then \
+            echo 1; \
+        else \
+            exit 1; \
+        fi\
+    '", SYMLINK+="serial%c"

--- a/vagrant/share/osmc/Vagrantfile
+++ b/vagrant/share/osmc/Vagrantfile
@@ -1,0 +1,89 @@
+  config.ssh.username = 'osmc'
+  config.ssh.password = 'osmc'
+
+  config.vm.boot_timeout = 1800
+
+  # https://raspberrypi.stackexchange.com/questions/117234/how-to-emulate-raspberry-pi-in-qemu
+  # https://blog.grandtrunk.net/2023/03/raspberry-pi-4-emulation-with-qemu/
+  # https://hechao.li/2021/12/20/Boot-Raspberry-Pi-4-Using-uboot-and-Initramfs/
+  # https://stackoverflow.com/questions/46380695/unable-to-add-raspbian-image-to-vagrant-libvirt-virtual-machine
+  config.vm.provider :libvirt do |domain, override|
+    # Default is `kvm`, but we need to support non-native arch.
+    domain.driver = 'qemu'
+
+    # https://github.com/vagrant-libvirt/vagrant-libvirt/issues/966#issuecomment-762308364
+    domain.features = []
+
+    # Otherwise:
+    # > Error while creating domain: Error saving the server: Call to
+    # > virDomainDefineXML failed: unsupported configuration: ps2 is not
+    # > supported by this QEMU binary
+    domain.inputs = []
+
+    domain.cpus = 2
+    domain.memory = 2048
+
+    domain.cpu_mode = 'custom'
+    domain.cpu_model = 'max'
+
+    domain.machine_arch = 'aarch64'
+    domain.machine_type = 'virt'
+
+    # The kernel and initrd have to be readable by the user running the libvirt
+    # daemon.  Create a world-readable temporary directory, copy the kernel and
+    # initrd into it, use these files for `domain.{kernel,initrd}`, and
+    # (finally) clean up after ourselves.
+    tmpdir = nil
+    cleanup = ->(*) do
+      begin
+        FileUtils.remove_entry(tmpdir)
+      rescue => e
+        raise(e) unless (e.is_a?(Errno::ENOENT) || tmpdir.nil?)
+      end
+    end
+
+    # Try to make Ruby's builtin exit handler take care of cleanup; this same
+    # block of code also executes in an `after` trigger defined below.
+    Kernel.at_exit(&cleanup)
+
+    override.trigger.before :all do |t|
+      t.name = 'Install kernel and initrd'
+      t.info = 'Installing the kernel and initrd to a world-readable location'
+      t.ruby do |env, machine|
+        tmpdir = Dir.mktmpdir(%w[vagrant-osmc- -assets])
+
+        # XXX This works:
+        #
+        # > machine.provider_config.foo = "bar"
+        #
+        # This does not:
+        #
+        # > machine.config.vm.provider :libvirt do |domain|
+        # >   domain.foo = "bar"
+        # > end
+        #
+        # Nor does this:
+        #
+        # > override.vm.provider :libvirt do |domain|
+        # >   domain.foo = "bar"
+        # > end
+        #
+        # That is, Vagrant seems to ignore/forget setting values defined using
+        # the latter two approaches, but uses/remembers such settings defined
+        # in the first approach.
+        machine.provider_config.kernel = kernel = File.expand_path('kernel', tmpdir)
+        machine.provider_config.initrd = initrd = File.expand_path('initrd', tmpdir)
+        machine.provider_config.cmd_line = 'rw earlyprintk loglevel=8 console=ttyAMA0,115200n8 init=/usr/sbin/init rootwait rootfstype=ext4 osmcdev=rbp4'
+
+        FileUtils.chmod(0777, tmpdir)
+        FileUtils.cp(File.expand_path('kernel', __dir__), kernel)
+        FileUtils.cp(File.expand_path('initrd', __dir__), initrd)
+      end
+    end
+
+    override.trigger.after :all do |t|
+      t.name = 'Clean up kernel and initrd'
+      t.info = 'Cleaning up the copied kernel and initrd'
+      t.ruby(&cleanup)
+    end
+  end

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -13,7 +13,7 @@ packages:
 # file attempts to execute `/usr/bin/kodi` :(
 kodi_executable: '/usr/bin/kodi-gbm'
 
-kodi_systemd_service: kodi
+kodi_service: kodi
 
 kodi_check_process_cmd: "ps -U {{ kodi_user }} -o command | grep -q ^/usr/bin/[k]odi-gbm"
 kodi_check_process_executable: "/bin/sh"

--- a/vars/Alpine.yml
+++ b/vars/Alpine.yml
@@ -1,0 +1,22 @@
+packages:
+  - acl
+  - curl
+  - kodi
+  - kodi-gbm
+  - kodi-openrc
+  - openrc
+  - procps-ng
+  - py3-lxml
+  - unzip
+
+# No `/usr/bin/kodi` on Alpine; there is `/usr/bin/kodi-standalone`, but this
+# file attempts to execute `/usr/bin/kodi` :(
+kodi_executable: '/usr/bin/kodi-gbm'
+
+kodi_systemd_service: kodi
+
+kodi_check_process_cmd: "ps -U {{ kodi_user }} -o command | grep -q ^/usr/bin/[k]odi-gbm"
+kodi_check_process_executable: "/bin/sh"
+
+kodi_query_version_cmd: "apk list -I kodi | awk '{print $1}' | awk -F- '/^kodi-[[:digit:]]/ { print ($(NF-1)) }'"
+kodi_query_version_executable: "{{ kodi_check_process_executable }}"

--- a/vars/Archlinux.yml
+++ b/vars/Archlinux.yml
@@ -1,9 +1,7 @@
 packages:
   - kodi
   - kodi-x11
-  - sqlite3
   - kodi-eventclients
-  - libxml2
   - unzip
   - python-lxml
   - acl

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,8 +1,6 @@
 packages:
   - kodi
-  - sqlite3
   - kodi-eventclients-kodi-send
-  - libxml2-utils
   - unzip
   - 'python*-lxml'
   - acl

--- a/vars/LibreELEC.yml
+++ b/vars/LibreELEC.yml
@@ -2,7 +2,7 @@ packages: []
 
 kodi_user_create: False
 
-kodi_systemd_service: kodi
+kodi_service: kodi
 
 # https://github.com/LibreELEC/LibreELEC.tv/blob/c1cab83d883d18e6bf110367693b85ab91fb4038/packages/mediacenter/kodi/system.d/kodi.service#L12
 kodi_executable: "/usr/lib/kodi/kodi.sh"

--- a/vars/LibreELEC.yml
+++ b/vars/LibreELEC.yml
@@ -1,5 +1,7 @@
 packages: []
 
+kodi_user: root
+
 kodi_user_create: False
 
 kodi_service: kodi

--- a/vars/OSMC.yml
+++ b/vars/OSMC.yml
@@ -7,7 +7,7 @@ packages:
 kodi_user: osmc
 kodi_user_create: False
 
-kodi_systemd_service: mediacenter
+kodi_service: mediacenter
 
 # https://github.com/osmc/osmc/blob/006c82b08ac7dfe9ba3d093ac8aa9b543134d048/package/mediacenter-osmc/files/lib/systemd/system/mediacenter.service#L9
 kodi_executable: "/usr/bin/mediacenter"

--- a/vars/OSMC.yml
+++ b/vars/OSMC.yml
@@ -1,7 +1,5 @@
 packages:
-  - libxml2-utils
   - python3-lxml
-  - sqlite3
   - file
 
 kodi_user: osmc

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,8 +1,6 @@
 packages:
   - kodi
-  - sqlite3
   - kodi-eventclients-kodi-send
-  - libxml2-utils
   - unzip
   - 'python*-lxml'
   - acl


### PR DESCRIPTION
Plus a smattering of other features and fixes.

Summary:

1. Add support for running LibreELEC under Vagrant.  This includes tooling for building a custom Vagrant box for LibreELEC guests, plus a Vagrant plugin defining the LibreELEC guest type.
2. Add support for running OSMC under Vagrant.  This includes tooling for building a custom Vagrant box for OSMC guests, but does not include any Vagrant plugin: OSMC is based on Debian, which already has a suitable Vagrant guest plugin.
3. Add support for Alpine Linux to the Ansible role, add an Alpine Linux Vagrant guest, and add Alpine Linux to the list of distributions tested in the GitHub Actions workflow.
4. Add a contributing guide with information on development tooling.
5. Use the `wait_for` module (which is for waiting for a particular host) instead of the `pause` module (which is for pausing Ansible's execution).
6. Use `root` as `kodi_user` on LibreELEC,
7. Ensure all groups in `kodi_groups` exist.
8. Use the `service` module rather than using the `systemd` module, and begin migration to using `kodi_service` rather than `kodi_systemd_service`.  Alpine, among other distribution, does not use systemd for service supervision and management.
9. Add a [Nix flake](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake) that provides, among other things, the tooling required to build LibreELEC and OSMC Vagrant boxes and to run Vagrant guests based on those boxes.

Thank you for your consideration!