### PR TITLE
feat(ci): run Nix flake checks in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,15 @@ jobs:
         # OpenRC under Alpine Linux) in a container.
         run: |
           ansible-playbook -vv --become -c local -i localhost, -e kodi_service_enabled=false ./tests/test.yml
+  nix:
+    name: Run Nix actions
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v8
+      - name: Set up Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v3
+      - name: Run Nix flake checks
+        run: |
+          nix flake check -L

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install testing dependencies
         run: |
           { apk add --no-cache ansible sudo ; } || :

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,9 @@
         system,
         ...
       }: {
+        # `nix run '.#' -- <devshell-command>`
+        apps.default = config.devShells.default.flakeApp;
+
         devshells.default = {
           commands = [
             # Local GitHub actions runner.  Run `act -j native` to execute the

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,8 @@
             ];
           };
         in {
+          inherit (config.devShells) default;
+
           rpi4-initrd = rpi4.config.system.build.initialRamdisk;
           rpi4-kernel = rpi4.config.system.build.kernel;
 


### PR DESCRIPTION
Basically what it says on the tin -- run `nix flake check` in the GitHub Actions workflow.  I've also added support for `nix run '.#' -- <devshell-command>`; that is, I've updated the Nix flake to make it possible to run commands inside this project's development shell without first having to enter the development shell with `nix develop`.