### PR TITLE
fix: ignore errors creating the groups in `kodi_groups`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,3 +29,9 @@ This file lists all notable changes to this project.
 - Use `root` as `kodi_user` on LibreELEC (#8).
 - Use the `wait_for` module instead of the `pause` module; now it should be
   possible to apply this role under the `free` strategy (#8).
+- Gracefully handle the absence of one or more prerequisites of the Ansible
+  `group` module (e.g. the absence of the `groupadd` command on LibreELEC)
+  (#10).
+- Unpack "complex" group specifications (dictionaries) when constructing the
+  `groups` attribute of the Ansible `user` task that creates `kodi_user`; this
+  task expects a list of strings specifying group names (#10).

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,6 +75,10 @@
     system: "{{ (item is mapping) | ternary((item.system | default(True) | bool), True) }}"
     gid: "{{ (item is mapping) | ternary((item.gid | default(omit)), omit) }}"
   with_items: "{{ kodi_groups }}"
+  # Some targets (e.g. LibreELEC) do not have `groupmod` and/or other
+  # dependencies of the `group` module.  Ignore errors; if any entries in
+  # `kodi_groups` are absent, the "Create Kodi user" task will fail.
+  ignore_errors: True
 
 - name: Create Kodi user
   user:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,7 +84,7 @@
   user:
     name: "{{ kodi_user }}"
     shell: "{{ kodi_shell }}"
-    groups: "{{ kodi_groups }}"
+    groups: "{{ (kodi_groups | select('mapping') | map(attribute='name') | list) + (kodi_groups | reject('mapping') | list) }}"
     append: True
   when: 'kodi_user_create | default(True) | bool'
   tags:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -39,6 +39,13 @@
     - role: "{{ playbook_dir | dirname }}"
       vars:
         kodi_attempt_start: True
+        kodi_groups:
+          - audio
+          - video
+          - input
+          - name: custom-group-for-testing
+            system: False
+            gid: 12345
         kodi_language: 'en_US'
         kodi_locale_country: 'United States'
         kodi_locale_timezone_country: 'United States'


### PR DESCRIPTION
Some supported targets lack one or more prerequisites of the Ansible `group` task.  For instance, the command `groupadd` is absent on LibreELEC.  This PR updates the `group` task to specify `ignore_errors`, punting any issues with absent groups to the subsequent `user` task the creates `kodi_user`.  If any groups specified in `kodi_groups` are absent, then the `user` task will fail.