### PR TITLE
Support addons on Kodi ver 21 and 22

### DIFF
--- a/files/get_kodi_addon.py
+++ b/files/get_kodi_addon.py
@@ -859,6 +859,8 @@ class Manager(FilesystemMixin, KodiConfigMixin):
                 18: "27",
                 19: "33",
                 20: "33",
+                21: "33",
+                22: "33",
             }
 
             if self.kodi_version.major not in database_version_map:


### PR DESCRIPTION
On Debian testing/trixie I got `Exception: unsupported Kodi version: 21` in `get_kodi_addon.py` `line 865, in database_version`

Adding support for v21 and v22.
According to https://kodi.wiki/view/Databases#Database_Versions
- v21 - Omega - Addon DB ver `33`
- v22 - Piers - Addon DB ver `33` (subject to change)
